### PR TITLE
Integrations for n2n 2.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "n2n_ntop"]
 	path = bundles/n2n_ntop
-	url = https://github.com/switch-iot/n2n_ntop.git
+	url = https://github.com/ntop/n2n.git
 [submodule "n2n_meyerd"]
 	path = bundles/n2n_meyerd
 	url = https://github.com/switch-iot/n2n.git

--- a/Hin2n_android/app/CMakeLists.txt
+++ b/Hin2n_android/app/CMakeLists.txt
@@ -2,10 +2,11 @@ project(Hin2n)
 cmake_minimum_required(VERSION 3.4.1)
 
 # N2n information
-set(N2N_VERSION 2.1.0)
+set(N2N_VERSION 2.7.0)
 set(N2N_OSNAME ${CMAKE_SYSTEM})
 set(N2N_MODIFY_VERSION v2s_0.1.0)
 set(N2N_MODIFY_AUTHOR "switchwang(https://github.com/switch-st) zhangbz(https://github.com/zhangbz)")
+add_definitions(-DCMAKE_BUILD)
 
 INCLUDE(TestBigEndian)
 TEST_BIG_ENDIAN(UIP_CONF_BYTE_ORDER)
@@ -15,7 +16,11 @@ else(${UIP_CONF_BYTE_ORDER} EQUAL 1)
 set(UIP_CONF_BYTE_ORDER UIP_LITTLE_ENDIAN)
 endif(${UIP_CONF_BYTE_ORDER} EQUAL 1)
 
-# @TODO set N2N_OPTION_AES for openssl, add_definitions(-DN2N_HAVE_AES)
+# TODO: add OpenSSL dependency
+#OPTION(N2N_OPTION_AES "USE AES" ON)
+#set(N2N_OPTION_AES ON)
+#find_package(OpenSSL REQUIRED)
+#add_definitions(-DN2N_HAVE_AES)
 
 if(CMAKE_BUILD_TYPE)
 if(NOT ${CMAKE_BUILD_TYPE} STREQUAL Debug)
@@ -24,9 +29,10 @@ endif(NOT ${CMAKE_BUILD_TYPE} STREQUAL Debug)
 else(CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE Release)
 endif(CMAKE_BUILD_TYPE)
-
+add_definitions(-DCMAKE_BUILD)
 
 add_definitions(-DN2N_VERSION=\"${N2N_VERSION}\" -DN2N_OSNAME=\"${N2N_OSNAME}\" -DN2N_MODIFY_VERSION=\"${N2N_MODIFY_VERSION}\" -DN2N_MODIFY_AUTHOR=\"${N2N_MODIFY_AUTHOR}\" -DUIP_CONF_BYTE_ORDER=\"${UIP_CONF_BYTE_ORDER}\")
+add_definitions(-DGIT_RELEASE="" -DPACKAGE_VERSION="${N2N_VERSION}" -DPACKAGE_OSNAME="${CMAKE_SYSTEM}")
 include_directories(src/main/cpp src/main/cpp/edge_jni src/main/cpp/slog src/main/cpp/tun2tap src/main/cpp/uip)
 
 add_library(edge_jni SHARED
@@ -43,12 +49,26 @@ add_library(edge_v2s SHARED
 target_link_libraries(edge_v2s n2n_v2s)
 target_link_libraries(edge_v2s slog)
 
+# -- ntop n2n
 add_library(edge_v2 SHARED
-                src/main/cpp/n2n_v2/android/edge_android.c
-                src/main/cpp/n2n_v2/edge_utils.c
-            )
-target_link_libraries(edge_v2 n2n_v2)
-target_link_libraries(edge_v2 slog)
+            src/main/cpp/n2n_v2/n2n.c
+            src/main/cpp/n2n_v2/edge_utils.c
+            src/main/cpp/n2n_v2/wire.c
+            src/main/cpp/n2n_v2/minilzo.c
+            src/main/cpp/n2n_v2/twofish.c
+            src/main/cpp/n2n_v2/transform_null.c
+            src/main/cpp/n2n_v2/transform_tf.c
+            src/main/cpp/n2n_v2/transform_aes.c
+            src/main/cpp/n2n_v2/random_numbers.c
+
+            src/main/cpp/n2n_v2/android/tuntap_android.c
+            src/main/cpp/n2n_v2/android/edge_android.c
+        )
+
+target_link_libraries(edge_v2 uip)
+target_link_libraries(edge_v2 log)
+#target_link_libraries(edge_v2 ${OPENSSL_LIBRARIES})
+#include_directories(${OPENSSL_INCLUDE_DIR})
 
 add_library(edge_v1 SHARED
                 src/main/cpp/n2n_v1/edge.c
@@ -70,21 +90,6 @@ add_library(n2n_v2s SHARED
             )
 target_link_libraries(n2n_v2s uip)
 target_link_libraries(n2n_v2s slog)
-
-add_library(n2n_v2 SHARED
-                src/main/cpp/n2n_v2/n2n.c
-                src/main/cpp/n2n_v2/n2n_keyfile.c
-                src/main/cpp/n2n_v2/wire.c
-                src/main/cpp/n2n_v2/minilzo.c
-                src/main/cpp/n2n_v2/twofish.c
-                src/main/cpp/n2n_v2/transform_null.c
-                src/main/cpp/n2n_v2/transform_tf.c
-                src/main/cpp/n2n_v2/transform_aes.c
-                src/main/cpp/n2n_v2/android/tuntap_android.c
-                src/main/cpp/n2n_v2/version.c
-            )
-target_link_libraries(n2n_v2 uip)
-target_link_libraries(n2n_v2 slog)
 
 add_library(n2n_v1 SHARED
                 src/main/cpp/n2n_v1/n2n.c

--- a/Hin2n_android/app/src/main/cpp/edge_jni/edge_jni.h
+++ b/Hin2n_android/app/src/main/cpp/edge_jni/edge_jni.h
@@ -2,8 +2,8 @@
 // Created by switchwang(https://github.com/switch-st) on 2018-04-13.
 //
 
-#ifndef _EDGE_ANDROID_H_
-#define _EDGE_ANDROID_H_
+#ifndef _EDGE_JNI_H_
+#define _EDGE_JNI_H_
 
 #ifdef __ANDROID_NDK__
 

--- a/Hin2n_android/app/src/main/java/wang/switchy/hin2n/Hin2nApplication.java
+++ b/Hin2n_android/app/src/main/java/wang/switchy/hin2n/Hin2nApplication.java
@@ -37,7 +37,7 @@ public class Hin2nApplication extends MultiDexApplication {
         System.loadLibrary("slog");
         System.loadLibrary("uip");
         System.loadLibrary("n2n_v2s");
-        System.loadLibrary("n2n_v2");
+        // n2n_v2 is part of edge_v2
         System.loadLibrary("n2n_v1");
         System.loadLibrary("edge_v2s");
         System.loadLibrary("edge_v2");


### PR DESCRIPTION
This pull request together with https://github.com/ntop/n2n/pull/259 allows hin2n to be compiled with the new n2n 2.7 code. AES encryption will be integrated later (requires openssl compilation).

Here is an overview of the hin2n structure before this PR:

- the switch-iot/n2n repository contains the actual code used by hin2n
- the switch-iot/hin2n contains the android gui code and the jni code to make n2n work in android (edge_jni)
- the repository ntop/n2n only contains a copy of the n2n code actually used by the hin2n project

With this pull request I wish to remove the switch-iot/n2n_ntop git repository from the equation in favor of ntop/n2n . This will avoid the code duplication and synchronization issues. ntop/n2n is actively maintained so any issues can be solved there. All the switch-iot/n2n modifications should have already been ported in https://github.com/ntop/n2n/pull/259 .